### PR TITLE
build(migrate): Remove unnecessary sea-orm dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,7 +1392,6 @@ name = "migration"
 version = "0.1.0"
 dependencies = [
  "async-std",
- "sea-orm",
  "sea-orm-migration",
 ]
 

--- a/edihkal/migration/Cargo.toml
+++ b/edihkal/migration/Cargo.toml
@@ -11,7 +11,6 @@ path = "src/lib.rs"
 
 [dependencies]
 async-std = { version = "^1", features = ["attributes", "tokio1"] }
-sea-orm = { version = "0.11", features = ["macros"], default-features = false }
 
 [dependencies.sea-orm-migration]
 version = "0.11"


### PR DESCRIPTION
The sea-orm dependency in the migration crate is redundant to the sea-orm-migration dependency.