### PR TITLE
fix: Handle unique constraint violation for other DBs (#39)

### DIFF
--- a/edihkal/src/db/mutation.rs
+++ b/edihkal/src/db/mutation.rs
@@ -10,8 +10,7 @@ where
     R: Resource,
     D: DataTrait<R>,
 {
-    // anyhow context is not used here to support `DatabaseError::UniqueViolation` conversion from
-    // `sqlx::Error`.
+    // anyhow context is not used here to support `DatabaseError::UniqueViolation` conversion from DbErr
     Ok(data.into_active_model().insert(db).await?)
 }
 


### PR DESCRIPTION
Improve error handling for unique constraint violations so it's not just checking a specific error code for postgres only.